### PR TITLE
Accurate Time onEverySecond

### DIFF
--- a/js/jquery.thooClock.js
+++ b/js/jquery.thooClock.js
@@ -411,7 +411,8 @@
                 if(x <= el.alarmCount && x !== 0){
                    $(el).trigger('onAlarm');
                 }
-                setTimeout(function(){startClock(x,y);},1000);
+                var synced_delay= 1000 - ((new Date().getTime()) % 1000);
+                setTimeout(function(){startClock(x,y);},synced_delay);
             }
 
             startClock(x,y);


### PR DESCRIPTION
This very simple fix set every setTimeout to happen exactly on each second and to not drift over time when the browser/computer is more or less busy.

Here is an example of the issue without the fix:

```
    $('#myclock').thooClock({
        onEverySecond:function(){
            var theDate = new Date();
            var s = theDate.getSeconds();
            console.log('seconds : '+s);
        }
    });
```

If you carefully watch the console and compare with the second hand, it starts to drift quickly (under a second obviously), but this become annoying when you want to use another time display at the same time.

This should also reduce the glitch happening when the second hand jump 2 second later or wait longer on the same second.

There is maybe a  more elegant fix, but this one seems to solve the isssue, with a single line of code.

HTH
