### PR TITLE
Fix example for Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
 
 		//clock plugin constructor
 		$('#myclock').thooClock({
-			size:document.height/1.4,
+			size:$(document).height()/1.4,
 			onAlarm:function(){
 				//all that happens onAlarm
 				$('#alarm1').show();


### PR DESCRIPTION
Your example did not worked on Firefox Mac 35.0.1 because _document.height_ don't return a value.

using jQuery methods  fix it

HTH
