### PR TITLE
2) setAlarm + date object input + alarm seconds precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Options
 Set Alarm time from outside the plugin:
 <pre>
   var strTime = '14:25'                       // must be hh:mm 
-  $.fn.thooClock.changeTime(strTime);
+  $.fn.thooClock.setAlarm(strTime);
 </pre>
 
 Clear Alarm from outside the plugin:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Options
     alarmHandTipColor:'#026729',            // color of tip of alarm hand
     hourCorrection:'+0',                    // hour correction e.g. +5 or -3
     alarmCount:1,                           // how many times should the onAlarm Callback function be fired
-    alarmTime:'14:25',                      // alarm time hh:mm
+    alarmTime:'14:25',                      // alarm time as Date object or String : "hh", "hh:mm", "hh:mm:ss"
     showNumerals:true,                      // show numerals on dial true/false
     brandText:'THOOYORK',                   // uppercase text on clock dial
     brandText2:'Germany',                   // lowercase text on clock dial
@@ -47,13 +47,25 @@ Options
  });
 </pre>
 
-Set Alarm time from outside the plugin:
+External Methods 
+-------
+
+**Set Alarm time:**
+
+From a date sting:
 <pre>
-  var strTime = '14:25'                       // must be hh:mm 
+  var strTime = '14:25'                       // must be "hh", "hh:mm" or "hh:mm:ss"
   $.fn.thooClock.setAlarm(strTime);
 </pre>
 
-Clear Alarm from outside the plugin:
+From a date object:
+<pre>
+	var alarm_date=new Date();
+	alarm_date.setHours(8,19,30);
+	$.fn.thooClock.setAlarm(alarm_date);
+</pre>
+
+**Clear Alarm:**
 <pre>
   $.fn.thooClock.clearAlarm();
 </pre>

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Options
     brandText:'THOOYORK',                   // uppercase text on clock dial
     brandText2:'Germany',                   // lowercase text on clock dial
     onAlarm:function(){                     // alarm callback function 
-      //callback on Alar
+      //callback on Alarm
     },
     offAlarm:function(){                    // end alarm callback
       //callback on Alarm end
@@ -51,4 +51,9 @@ Set Alarm time from outside the plugin:
 <pre>
   var strTime = '14:25'                       // must be hh:mm 
   $.fn.thooClock.changeTime(strTime);
+</pre>
+
+Clear Alarm from outside the plugin:
+<pre>
+  $.fn.thooClock.clearAlarm();
 </pre>

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
 
 	$('#set').click(function(){
 		var inp = $('#altime').val();
-		$.fn.thooClock.changeTime(inp);
+		$.fn.thooClock.setAlarm(inp);
 	});
 
 	

--- a/index.html
+++ b/index.html
@@ -86,7 +86,6 @@
 	
 	function alarmBackground(y){
 			var color;
-			console.log(y);
 			if(y===1){
 				color = '#CC0000';
 				y=0;

--- a/index.html
+++ b/index.html
@@ -74,7 +74,6 @@
 
 
 	$('#turnOffAlarm').click(function(){
-		$('#myclock').trigger('offAlarm');
 		$.fn.thooClock.clearAlarm();
 	});
 

--- a/js/jquery.thooClock.js
+++ b/js/jquery.thooClock.js
@@ -85,7 +85,7 @@
 
             //set alarmtime from outside:
             
-            $.fn.thooClock.changeTime = function(newtime){
+            $.fn.thooClock.setAlarm = function(newtime){
                     //alert(el.id);
                     el.alarmTime = newtime;   
             };

--- a/js/jquery.thooClock.js
+++ b/js/jquery.thooClock.js
@@ -86,8 +86,27 @@
             //set alarmtime from outside:
             
             $.fn.thooClock.setAlarm = function(newtime){
+                    var thedate;
+                    if(newtime instanceof Date){
+                    	//keep date object
+                    	thedate=newtime;
+                    }
+                    else{
+						//convert from string formatted like hh[:mm[:ss]]]
+						var arr = newtime.split(':');
+						thedate=new Date();
+						for(var i= 0; i <3 ; i++){
+							//force to int
+							arr[i]=Math.floor(arr[i]);
+							//check if NaN or invalid min/sec
+							if( arr[i] !==arr[i] || arr[i] > 59) arr[i]=0 ;
+							//no more than 24h
+							if( i==0 && arr[i] > 23) arr[i]=0 ;
+						}
+						thedate.setHours(arr[0],arr[1],arr[2]);
+                    }
                     //alert(el.id);
-                    el.alarmTime = newtime;   
+                    el.alarmTime = thedate;   
             };
 
             $.fn.thooClock.clearAlarm = function(){
@@ -271,12 +290,10 @@
 
             function timeToDecimal(time){
                 var h,
-                    m,
-                    aryTime;
+                    m;
                 if(time !== undefined){
-                    aryTime = time.split(':');
-                    h = twelvebased(aryTime[0]);
-                    m = aryTime[1];
+                    h = twelvebased(time.getHours());
+                    m = time.getMinutes();
                 }
                 return parseInt(h,10) + (m/60);
             }
@@ -398,13 +415,10 @@
                 }
                
                 if(el.alarmTime !== undefined){
-                    atime = el.alarmTime.split(':');
-                    exth = atime[0];
-                    extm = atime[1];
-                    allExtM = (parseInt(exth,10)*60)+parseInt(extm,10);
+                    allExtM = (el.alarmTime.getHours()*60*60) + (el.alarmTime.getMinutes() *60) + el.alarmTime.getSeconds();
                 }
 
-                allAlarmM = (parseInt(hours,10)*60) + parseInt(mins,10);
+                allAlarmM = (hours*60*60) + (mins*60) + s;
 
                 //set alarm loop counter
                 //if(h >= timeToDecimal(twelvebased(el.alarmTime)){

--- a/js/jquery.thooClock.js
+++ b/js/jquery.thooClock.js
@@ -92,7 +92,7 @@
 
             $.fn.thooClock.clearAlarm = function(){
                     el.alarmTime = undefined;
-                    this.startClock(0,0);
+                    startClock(0,0);
             };
         
 

--- a/js/jquery.thooClock.js
+++ b/js/jquery.thooClock.js
@@ -93,6 +93,7 @@
             $.fn.thooClock.clearAlarm = function(){
                     el.alarmTime = undefined;
                     startClock(0,0);
+                    $(el).trigger('offAlarm');
             };
         
 


### PR DESCRIPTION
_(should be applied after PR #6 or merge might not work)_
- _changeTime_ method renamed to **setAlarm** for consistency with _clearAlarm_ method name
- remove verbose console.log from index.html
- setAlarm now accept either :
  - A date object
  - A string formatted either as : "hh" , "hh:mm", "hh:mm:ss"
- more tolerant with string times inputs.
- Alarm time now uses seconds precision (if set)
- Documentation updated to reflect changes.

BTW Thanks for having so fastly implemented all proposed issues. 
Cheers !!!!!! :+1:
