### PR TITLE
Support timezone with minutes offsets

### DIFF
--- a/js/jquery.thooClock.js
+++ b/js/jquery.thooClock.js
@@ -337,7 +337,18 @@
                 ctx.restore();
             }
 
-            function numberCorrection(num){
+            function timeCorrection(difference, unit) {
+                var parts = difference.split('.');
+                if (unit === 'hours') {
+                    return hoursCorrection(parts[0]);
+                } else if (unit === 'minutes') {
+                    var minutes = parts[1];
+                    if (!(+ minutes)) return 0;
+                    return minutesCorrection(difference.charAt(0) + '0.' + minutes);
+                }
+            }
+
+            function hoursCorrection(num){
                 if(num !== '+0' && num !== ''){
                     if(num.charAt(0) === '+'){
                         //addNum
@@ -351,6 +362,11 @@
                 else{
                     return 0;
                 }
+            }
+
+            function minutesCorrection(num) {
+                var minutesInHours = Number(num);
+                return minutesInHours ? minutesInHours * 60 : 0;
             }
 
             //listener
@@ -395,9 +411,9 @@
                 theDate = new Date();
                 s = theDate.getSeconds();
                 mins = theDate.getMinutes();
-                m = mins + (s/60);
+                m = (mins + timeCorrection(el.hourCorrection, 'minutes')) + (s/60);
                 hours = theDate.getHours();
-                h = twelvebased(hours + numberCorrection(el.hourCorrection)) + (m/60);
+                h = twelvebased(hours + timeCorrection(el.hourCorrection, 'hours')) + (m/60);
 
                 ctx.clearRect(-radius,-radius,el.size,el.size);
 


### PR DESCRIPTION
Hi @thooyork ! Thanks for creating a great jQuery clock plugin. I've been using this for a current project and noticed that it lacks support for timezones with minutes offsets. There's also an existing [issue ](https://github.com/thooyork/thooClock/issues/15) about this. Kindly review my proposed implementation. :smiley: 

Proposed solution will support timezones such as:
1. (UTC+04:30) | Kabul
2. (UTC-04:30) | Caracas
3. (UTC+06:30) | Yangon (Rangoon)
4. (UTC+05:30) | Chennai, Kolkata, Mumbai, New Delhi
5. (UTC+03:30) | Tehran
6. (UTC+05:45) | Kathmandu

The idea is to retain your original code and just added new functions `minutesCorrection` and `timeCorrection`. To accommodate minutes offsets, they are to be converted to hours (e.g. 30 mins -> 0.50hr, 45 mins -> 0.75hr) to retain the format needed for `hourCorrection` options property. For example, if the selected timezone is GMT +9:30 and the current timezone is GMT +8:00, the `hourCorrection` will have the value `+1.50`.

~ Kris ~